### PR TITLE
Fix sessions expiring early on certain browsers

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -86,6 +86,7 @@ db.initialize().then(() => {
       name: 'loved_sid',
       proxy: true,
       resave: false,
+      rolling: true,
       saveUninitialized: false,
       secret: config.sessionSecret,
       store: new MysqlSessionStore(

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -126,9 +126,6 @@ db.initialize().then(() => {
         return response.status(422).json({ error: 'No authorization code provided' });
       }
 
-      console.log(request.session);
-      console.log(request.query.state)
-
       if (!request.query.state || request.query.state !== state) {
         return response.status(422).json({ error: 'Invalid state. Try logging in again' });
       }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -80,8 +80,8 @@ db.initialize().then(() => {
     session({
       cookie: {
         httpOnly: true,
+        maxAge: 604800000, // 7 days
         secure: config.httpsAlways,
-        maxAge: 604800000
       },
       name: 'loved_sid',
       proxy: true,

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -81,6 +81,7 @@ db.initialize().then(() => {
       cookie: {
         httpOnly: true,
         secure: config.httpsAlways,
+        maxAge: 604800000
       },
       name: 'loved_sid',
       proxy: true,
@@ -124,6 +125,9 @@ db.initialize().then(() => {
       if (!request.query.code) {
         return response.status(422).json({ error: 'No authorization code provided' });
       }
+
+      console.log(request.session);
+      console.log(request.query.state)
 
       if (!request.query.state || request.query.state !== state) {
         return response.status(422).json({ error: 'Invalid state. Try logging in again' });


### PR DESCRIPTION
the session's `Expiry` cookie was set to expire upon the end of the user's "Session", which entails commonly on browsers like chrome and safari that it would be automatically deleted when the browser was closed; so i added a max age parameter to the `express-session` object to fix this and utilize the expected 7-day session expiration time

fixes #114