### PR TITLE
Add `blank` for `Beatmap.tsx`

### DIFF
--- a/client/src/Beatmap.tsx
+++ b/client/src/Beatmap.tsx
@@ -15,7 +15,7 @@ export default function Beatmap({ beatmapset, gameMode }: BeatmapProps) {
   }
 
   return (
-    <a className='beatmap' href={link}>
+    <a className='beatmap' href={link} target="_blank">
       <div className='beatmap-artist'>{beatmapset.artist}</div>
       <div className='beatmap-title'>{beatmapset.title}</div>
     </a>


### PR DESCRIPTION
Currently clicking on the beatmapset will open the current page directly, which will cause the loved.sh page to exit. Adding the blank attribute causes the beatmapset to open in a new TAB